### PR TITLE
feat: Limit tags to 5 per post

### DIFF
--- a/src/services/post.service.ts
+++ b/src/services/post.service.ts
@@ -19,6 +19,9 @@ type DBTransaction = SQLiteTransaction<any, any, any, any>;
 
 // Helper function to process tags
 const processTags = async (postId: string, tagNames: string[] | undefined, tx: DBTransaction): Promise<void> => {
+  if (tagNames && tagNames.length > 5) {
+    throw new Error("A post can have a maximum of 5 tags.");
+  }
   // 1. Delete existing tag associations for the post
   await tx.delete(postTags).where(eq(postTags.postId, postId));
 


### PR DESCRIPTION
I've modified the `processTags` function in `src/services/post.service.ts` to enforce a maximum of 5 tags per post.

If you attempt to create or update a post with more than 5 tags, an error will be thrown. This ensures that the number of tags associated with a post remains within the defined limit.